### PR TITLE
Fix and improve cache invalidations

### DIFF
--- a/redis.services.yml
+++ b/redis.services.yml
@@ -2,4 +2,6 @@ services:
   cache.backend.redis:
     class: Drupal\redis\CacheBackendFactory
   redis.phpredis.invalidator:
-      class: Drupal\redis\Cache\PhpRedisCacheInvalidator
+    class: Drupal\redis\Cache\PhpRedisCacheInvalidator
+    tags:
+      - { name: cache_tags_invalidator }

--- a/redis.services.yml
+++ b/redis.services.yml
@@ -1,3 +1,5 @@
 services:
   cache.backend.redis:
     class: Drupal\redis\CacheBackendFactory
+  redis.phpredis.invalidator:
+      class: Drupal\redis\Cache\PhpRedisCacheInvalidator

--- a/src/AbstractBackend.php
+++ b/src/AbstractBackend.php
@@ -20,8 +20,8 @@ abstract class AbstractBackend
     {
         $ret = null;
 
-        if (isset($GLOBALS['drupal_test_info']) && !empty($test_info['test_run_id'])) {
-            $ret = $test_info['test_run_id'];
+        if ($test_prefix = drupal_valid_test_ua()) {
+            $ret = $test_prefix;
         } else {
             $prefixes = ''; //variable_get('cache_prefix', '');
 

--- a/src/Cache/PhpRedis.php
+++ b/src/Cache/PhpRedis.php
@@ -132,7 +132,7 @@ class PhpRedis extends CacheBase {
     $client = ClientFactory::getClient();
     // The first entry is where to store, the second is the same,
     // so that existing entries are kept.
-    $client->sUnionStore($this->getDeletedMetaSet(), $this->getDeletedMetaSet(), $this->getTagForBin());
+    $client->sUnionStore($this->getDeletedMetaSet(), $this->getDeletedMetaSet(), $this->getKeysByTagSet($this->getTagForBin()));
   }
 
   /**
@@ -162,7 +162,7 @@ class PhpRedis extends CacheBase {
     $client = ClientFactory::getClient();
     // The first entry is where to store, the second is the same,
     // so that existing entries are kept.
-    $client->sUnionStore($this->getStaleMetaSet(), $this->getStaleMetaSet(), $this->getTagForBin());
+    $client->sUnionStore($this->getStaleMetaSet(), $this->getStaleMetaSet(), $this->getKeysByTagSet($this->getTagForBin()));
   }
 
   /**

--- a/src/Cache/PhpRedis.php
+++ b/src/Cache/PhpRedis.php
@@ -129,8 +129,10 @@ class PhpRedis extends CacheBase {
    * {@inheritdoc}
    */
   public function deleteAll() {
-    $tag = $this->getTagForBin();
-    $this->invalidateTags(array($tag));
+    $client = ClientFactory::getClient();
+    // The first entry is where to store, the second is the same,
+    // so that existing entries are kept.
+    $client->sUnionStore($this->getDeletedMetaSet(), $this->getDeletedMetaSet(), $this->getTagForBin());
   }
 
   /**
@@ -156,26 +158,11 @@ class PhpRedis extends CacheBase {
   /**
    * {@inheritdoc}
    */
-  public function invalidateTags(array $tags) {
-    $client = ClientFactory::getClient();
-    // Build a list of cache tags, the first entry is where to store, the
-    // second is the same, so that existing entries are kept.
-    $lists = [$this->getStaleMetaSet(), $this->getStaleMetaSet()];
-
-    // Extend the list for each cache tag.
-    foreach ($tags as $tag) {
-      $lists[] = $this->getKeysByTagSet($tag);
-    }
-    // Execute the command.
-    call_user_func_array(array($client, 'sUnionStore'), $lists);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function invalidateAll() {
-    $tag = $this->getTagForBin();
-    $this->invalidateTags(array($tag));
+    $client = ClientFactory::getClient();
+    // The first entry is where to store, the second is the same,
+    // so that existing entries are kept.
+    $client->sUnionStore($this->getStaleMetaSet(), $this->getStaleMetaSet(), $this->getTagForBin());
   }
 
   /**

--- a/src/Cache/PhpRedisCacheInvalidator.php
+++ b/src/Cache/PhpRedisCacheInvalidator.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\redis\Cache\PhpRedisCacheInvalidator.
+ */
+
+namespace Drupal\redis\Cache;
+
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\redis\AbstractBackend;
+use Drupal\redis\ClientFactory;
+
+/**
+ * PhpRedis cache backend.
+ */
+class PhpRedisCacheInvalidator extends AbstractBackend implements CacheTagsInvalidatorInterface {
+
+  /**
+   * Return the key for the set holding the keys of stale entries.
+   */
+  protected function getStaleMetaSet() {
+    return parent::getKey('meta/stale');
+  }
+
+  /**
+   * Return the key for the keys-by-tag set.
+   */
+  protected function getKeysByTagSet($tag) {
+    return parent::getKey('meta/keysByTag:' . $tag);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function invalidateTags(array $tags) {
+    $client = ClientFactory::getClient();
+    // Build a list of cache tags, the first entry is where to store, the
+    // second is the same, so that existing entries are kept.
+    $lists = [$this->getStaleMetaSet(), $this->getStaleMetaSet()];
+
+    // Extend the list for each cache tag.
+    foreach ($tags as $tag) {
+      $lists[] = $this->getKeysByTagSet($tag);
+    }
+    // Execute the command.
+    call_user_func_array(array($client, 'sUnionStore'), $lists);
+  }
+
+}

--- a/src/CacheBase.php
+++ b/src/CacheBase.php
@@ -18,7 +18,7 @@ use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
  * For a detailed history of flush modes see:
  *   https://drupal.org/node/1980250
  */
-abstract class CacheBase extends AbstractBackend implements CacheBackendInterface, CacheTagsInvalidatorInterface {
+abstract class CacheBase extends AbstractBackend implements CacheBackendInterface {
 
   /**
    * Temporary cache items lifetime is infinite.
@@ -133,7 +133,7 @@ abstract class CacheBase extends AbstractBackend implements CacheBackendInterfac
    * Return the key for the tag used to specify the bin of cache-entries.
    */
   protected function getTagForBin() {
-    return 'x-redis-bin:' . $this->bin;
+    return parent::getKey('meta/bin:' . $this->bin);
   }
 
   /**

--- a/src/CacheBase.php
+++ b/src/CacheBase.php
@@ -133,7 +133,7 @@ abstract class CacheBase extends AbstractBackend implements CacheBackendInterfac
    * Return the key for the tag used to specify the bin of cache-entries.
    */
   protected function getTagForBin() {
-    return parent::getKey('meta/bin:' . $this->bin);
+    return 'x-redis-bin:' . $this->bin;
   }
 
   /**

--- a/src/Tests/Cache/PhpRedisUnitTest.php
+++ b/src/Tests/Cache/PhpRedisUnitTest.php
@@ -25,17 +25,6 @@ class PhpRedisUnitTest extends GenericCacheBackendUnitTestBase {
   public static $modules = array('system', 'redis');
 
   /**
-   * {@inheritdoc}
-   */
-  public function setUp() {
-    parent::setUp();
-
-    // Set cache tag invalidator.
-    $backend = $this->getCacheBackend();
-    \Drupal::service('cache_tags.invalidator')->addInvalidator($backend);
-  }
-
-  /**
    * Creates a new instance of PhpRedis cache backend.
    *
    * @return \Drupal\redis\Cache\PhpRedis


### PR DESCRIPTION
invalidateTags() is currently broken, because it implements sUnionStore incorrectly. That command _replaces_ the destination list, so only the last cache tag invalidation "works".

Instead of the current code, we need to send a single command, that looks like this: sunionstore stale stale tag1list tag2list.

If there are better ways to not lose what is already in stale, someone please tell me.

I also want extract the invalidateKeys() implementation into a separate cache tags invalidation service, right now, it is called per bin, but we do not store the cache tag list s per bin, so we process that 10x instead of once.
