### PR TITLE
Changed unit test use statement for QueueTest

### DIFF
--- a/tests/src/Kernel/QueueTest.php
+++ b/tests/src/Kernel/QueueTest.php
@@ -8,7 +8,7 @@
 namespace Drupal\Tests\redis\Kernel;
 
 use Drupal\redis\ClientFactory;
-use \Drupal\KernelTests\Core\Queue\QueueTest as CoreQueueTest;
+use Drupal\system\Tests\Queue\QueueTest as CoreQueueTest;
 
 /**
  * Tests the Redis queue functions.


### PR DESCRIPTION
Redis unit tests were failing for me.  Changing it back to Drupal\system\Tests is allowing them to run successfully.  Drupal version 8.0.6 at the time of this commit.
