### PR TITLE
Add sentinel mode 

### DIFF
--- a/README.PhpRedis.txt
+++ b/README.PhpRedis.txt
@@ -16,6 +16,23 @@ will probably need to compile it yourself.
 Default behavior is to connect via tcp://localhost:6379 but you might want to
 connect differently.
 
+Use the Sentinel high availability mode
+---------------------------------------
+
+Redis can provide a master/slave mode with sentinels server monitoring them.
+More information about setting it : https://redis.io/topics/sentinel.
+
+This mode needs the following settings:
+
+Modify the host as follow:
+    // Sentinels instances list with hostname:port format.
+    $settings['redis.connection']['host']      = array('1.2.3.4:5000','1.2.3.5:5000','1.2.3.6:5000');
+
+Add the new instance setting:
+
+    // Redis instance name.
+    $settings['redis.connection']['instance']  = 'instance_name'; 
+
 Connect via UNIX socket
 -----------------------
 


### PR DESCRIPTION
This a simpler version of https://www.drupal.org/node/2835403, it only contains the sentinel mode.
I try to be less invasive, so I didn't touch the clientInterface to add an extra variable.
The code has been tested with a master/slave + 3 sentinels and check with code sniffer (--standard=Drupal).

A specific test is missing, but I didn't know how to setup or mock a full redis+sentinel stack.

O'Briat
 